### PR TITLE
docs: add deployment guide and link from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,15 @@ curl -X PUT https://your-api-url/tasks/{taskId} \
   ```
 ---
 
+# 🚀 Deployment Guide
+
+This guide explains how to deploy the Task Manager API using AWS SAM CLI.
+
+```markdown
+📖 [Deployment Guide](docs/deployment-guide.md)
+```
+---
+
 ## 🛠️ Troubleshooting Snapshot
 
 |   Issue Description                             | ❗ Error Message / Symptom                                      | ✅ Resolution Summary                                           |

--- a/README.md
+++ b/README.md
@@ -122,9 +122,8 @@ curl -X PUT https://your-api-url/tasks/{taskId} \
 
 This guide explains how to deploy the Task Manager API using AWS SAM CLI.
 
-```markdown
 📖 [Deployment Guide](docs/deployment-guide.md)
-```
+
 ---
 
 ## 🛠️ Troubleshooting Snapshot

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ curl -X PUT https://your-api-url/tasks/{taskId} \
 
 This guide explains how to deploy the Task Manager API using AWS SAM CLI.
 
-📖 [Deployment Guide](docs/deployment-guide.md)
+📖 [Deployment Guide](doc/deployment-guide.md)
 
 ---
 

--- a/doc/deployment-guide.md
+++ b/doc/deployment-guide.md
@@ -1,0 +1,37 @@
+# 🚀 Deployment Guide
+
+This guide explains how to deploy the Task Manager API using AWS SAM CLI.
+
+## Prerequisites
+
+- AWS CLI configured with credentials
+- SAM CLI installed
+- Docker (for local builds)
+- AWS account with permissions to deploy Lambda, API Gateway, and DynamoDB
+
+## Deployment Steps
+
+1. **Build the project**
+   ```bash
+   sam build
+2. **Deploy to AWS**
+sam deploy --guided
+
+3. **Provide required parameters**
+- Stack name
+- AWS region
+- Confirm changeset
+- Save configuration for future deploys
+
+## Post-Deployment
+
+    Note the API Gateway endpoint from the output
+
+    Verify Lambda functions and DynamoDB table in AWS Console
+
+## Cleanup
+
+To delete the stack:
+```bash
+aws cloudformation delete-stack --stack-name your-stack-name
+```

--- a/doc/deployment-guide.md
+++ b/doc/deployment-guide.md
@@ -26,10 +26,8 @@ sam deploy --guided
 - Save configuration for future deploys
 
 ## Post-Deployment
-
-    Note the API Gateway endpoint from the output
-
-    Verify Lambda functions and DynamoDB table in AWS Console
+- Note the API Gateway endpoint from the output
+- Verify Lambda functions and DynamoDB table in AWS Console
 
 ## Cleanup
 

--- a/doc/deployment-guide.md
+++ b/doc/deployment-guide.md
@@ -11,15 +11,15 @@ This guide explains how to deploy the Task Manager API using AWS SAM CLI.
 
 ## Deployment Steps
 
-1. **Build the project**
+**1. Build the project**
    ```bash
    sam build
    ```
-2. **Deploy to AWS**
+**2. Deploy to AWS**
 ```bash
 sam deploy --guided
 ```
-3. **Provide required parameters**
+**3. Provide required parameters**
 - Stack name
 - AWS region
 - Confirm changeset

--- a/doc/deployment-guide.md
+++ b/doc/deployment-guide.md
@@ -14,9 +14,11 @@ This guide explains how to deploy the Task Manager API using AWS SAM CLI.
 1. **Build the project**
    ```bash
    sam build
+   ```
 2. **Deploy to AWS**
+```bash
 sam deploy --guided
-
+```
 3. **Provide required parameters**
 - Stack name
 - AWS region


### PR DESCRIPTION
This PR adds a dedicated deployment guide in docs/deployment-guide.md and links it from the README. It modularizes deployment instructions and improves clarity for contributors.

Closes #5 